### PR TITLE
Roughed out an XR API.

### DIFF
--- a/PSEUDO API 1.md
+++ b/PSEUDO API 1.md
@@ -20,6 +20,7 @@
 
 ### Todo
 
+- indicate that the display is opaque or clear
 - calibration
 
 ## Reality
@@ -41,8 +42,10 @@
 
 ### Todo
 
+- requesting reality data (e.g. camera image)
 - configuration
 - anchors
+- picking
 - manifold instead of point cloud
 
 ## XRPointCloud
@@ -68,6 +71,7 @@
 		attribute double depthFar;
 
 		attribute XRLayer layer;
+		attribute Reality reality;
 
 		Promise<sequence <Reality>> getRealities();
 

--- a/PSEUDO API 1.md
+++ b/PSEUDO API 1.md
@@ -3,6 +3,9 @@
 
 	interface XR {
 		Promise<sequence<XRDisplay>> getDisplays();
+
+		attribute EventHandler ondisplayconnect;
+		attribute EventHandler ondisplaydisconnect;
 	};
 
 
@@ -33,9 +36,11 @@
 		attribute double depthFar;
 
 		attribute XRLayer layer;
-		attribute Reality reality; // Defaults to an empty (VR) reality
+		attribute Reality reality; // Defaults to most recently used Reality
 
-		Promise<sequence <Reality>> getRealities(); // Always returns at least the default empty reality
+
+		Reality createEmptyReality();
+		Promise<sequence <Reality>> getRealities();
 		Promise<boolean> requestRealityChange(Reality reality); // resolves true if the request is accepted
 
 		Promise<XRFrameOfReference> requestFrameOfReference(XRFrameOfReferenceType type);
@@ -59,8 +64,8 @@
 		readonly attribute XRCoordinates stageLocation;
 		readonly attribute isPassthrough; // True if the Reality is a view of the outside world, not a fully VR
 
-		Promise<boolean> requestStageLocation(float x, float y float z, XRCoordinates)
-		Promise<boolean> requestResetStageLocation()
+		Promise<boolean> requestStageLocation(XRCoordinates coordinates);
+		Promise<boolean> requestResetStageLocation();
 
 		attribute EventHandler onchange;
 	};
@@ -104,11 +109,14 @@
 		readonly attribute FrozenArray<XRView> views;
 
 		readonly attribute boolean hasPointCloud;
+		readonly attribute XRPointCloud pointCloud;
+
+		readonly attribute boolean hasManifold;
+		readonly attribute XRManifold manifold;
+
 		readonly attribute boolean hasLightEstimate;
-
-		Promise<XRPointCloud> getPointCloud()
-		Promise<XRLightEstimate> getLightEstimate()
-
+		readonly attribute XRLightEstimate lightEstimate;
+		
 		long addAnchor(XRAnchor anchor);
 		void removeAnchor(long id);
 		XRAnchor? getAnchor(long id);
@@ -116,6 +124,9 @@
 
 		XRDisplayPose? getDisplayPose(XRCoordinateSystem coordinateSystem);
 	};
+
+
+- access camera image buffer aor texture
 
 ## XRView
 
@@ -135,10 +146,18 @@
 		readonly attribute long height;
 	};
 
+## XRCartographicCoordinates
+
+	interface XRCartographicCoordinates {
+		attribute float latitude;
+		attribute float longitude;
+		attribute float altitude;
+	}
+
 ## XRCoordinateSystem
 
-	interface XRCoordinateSystem: EventTarget {
-		readonly attribute Coordinates? coordinates; // https://dev.w3.org/geo/api/spec-source.html#coordinates
+	interface XRCoordinateSystem {
+		readonly attribute XRCartographicCoordinates? mapLocation;
 
 		Float32Array? getTransformTo(XRCoordinateSystem other);
 	};
@@ -146,11 +165,11 @@
 ## XRCoordinates
 
 	interface XRCoordinates {
-		readonly attribute XRCoordinateSystem
+		attribute XRCoordinateSystem;
 		attribute float x;
 		attribute float y;
 		attribute float z;
-	}
+	};
 
 ## XRDisplayPose
 

--- a/PSEUDO API 1.md
+++ b/PSEUDO API 1.md
@@ -1,0 +1,166 @@
+
+## XR
+
+	interface XR {
+		Promise<sequence<XRDisplay>> getDisplays();
+	};
+
+
+## XRDisplay
+
+	interface XRDisplay {
+		readonly attribute DOMString displayName;
+		readonly attribute boolean isExternal;
+
+		Promise<boolean> supportsSession(XRSessionCreateParametersInit parameters);
+		Promise<XRSession> requestSession(XRSessionCreateParametersInit parameters);
+
+		attribute EventHandler ondeactivate;
+	};
+
+### Todo
+
+- calibration
+
+## Reality
+
+	interface Reality {
+		readonly atttribute DOMString realityName;
+		readonly attribute boolean hasPointCloud;
+		readonly attribute XRCoordinates stageLocation;
+
+		Promise<boolean> requestStageLocation(float x, float y float z, XRCoordinates)
+		Promise<boolean> requestResetStageLocation()
+
+		Promise<XRPointCloud> getPointCloud()
+
+		Promise<XRLightEstimate> getLightEstimate()
+
+		attribute EventHandler onchange;
+	};
+
+### Todo
+
+- configuration
+- anchors
+- manifold instead of point cloud
+
+## XRPointCloud
+
+	interface XRPointCloud {
+		readonly attribute Float32Array points;
+	}
+
+## XRLightEstimate
+
+	interface XRLightEstimate {
+		readonly attribute float ambientIntensity;
+		readonly attribute float ambientColorTemperature;
+	}
+
+## XRSession
+
+	interface XRSession : EventTarget {
+		readonly attribute XRDisplay display;
+		readonly attribute XRSessionCreateParameters createParameters;
+
+		attribute double depthNear;
+		attribute double depthFar;
+
+		attribute XRLayer layer;
+
+		Promise<sequence <Reality>> getRealities();
+
+		Promise<XRFrameOfReference> requestFrameOfReference(XRFrameOfReferenceType type);
+
+		long requestFrame(XRFrameRequestCallback callback);
+		void cancelFrame(long handle);
+
+		Promise<void> endSession();
+
+		attribute EventHandler onblur;
+		attribute EventHandler onfocus;
+		attribute EventHandler onresetpose;
+		attribute EventHandler onended;
+	};
+
+## XRPresentationFrame
+
+	interface XRPresentationFrame {
+		readonly attribute FrozenArray<XRView> views;
+
+		XRDisplayPose? getDisplayPose(XRCoordinateSystem coordinateSystem);
+	};
+
+## XRCoordinateSystem
+
+	interface XRCoordinateSystem: EventTarget {
+		readonly attribute Coordinates? coordinates; // https://dev.w3.org/geo/api/spec-source.html#coordinates
+
+		Float32Array? getTransformTo(XRCoordinateSystem other);
+	};
+
+## XRCoordinates
+
+	interface XRCoordinates {
+		readonly attribute XRCoordinateSystem
+		attribute float x;
+		attribute float y;
+		attribute float z;
+	}
+
+## XRView
+
+	interface XRView {
+		readonly attribute XREye eye;
+		readonly attribute Float32Array projectionMatrix;
+
+		XRViewport? getViewport(XRLayer layer);
+	};
+
+## XRViewport
+
+	interface XRViewport {
+		readonly attribute long x;
+		readonly attribute long y;
+		readonly attribute long width;
+		readonly attribute long height;
+	};
+
+## XRDisplayPose
+
+	interface XRDisplayPose {
+		readonly attribute Float32Array poseModelMatrix;
+
+		Float32Array getViewMatrix(XRView view);
+	};
+
+## XRLayer
+
+	interface XRLayer {};
+
+	typedef (WebGLRenderingContext or WebGL2RenderingContext) XRWebGLRenderingContext;
+
+	[Constructor(XRSession session, XRWebGLRenderingContext context, optional XRWebGLLayerInit layerInit)]
+
+	interface XRWebGLLayer : XRLayer {
+		readonly attribute XRWebGLRenderingContext context;
+
+		readonly attribute boolean antialias;
+		readonly attribute boolean depth;
+		readonly attribute boolean stencil;
+		readonly attribute boolean alpha;
+		readonly attribute boolean multiview;
+
+		readonly attribute WebGLFramebuffer framebuffer;
+		readonly attribute long framebufferWidth;
+		readonly attribute long framebufferHeight;
+
+		void requestViewportScaling(double viewportScaleFactor);
+	};
+
+### Todo
+
+- focus / blur
+- misbehavior
+

--- a/PSEUDO API 1.md
+++ b/PSEUDO API 1.md
@@ -8,6 +8,8 @@
 		attribute EventHandler ondisplaydisconnect;
 	};
 
+_The interfaces with "VR" in the name have been changed to "XR" to indicate that they are used for both VR and AR._
+
 ## XRDisplay
 
 	interface XRDisplay : EventTarget {
@@ -21,6 +23,8 @@
 	};
 
 Each XRDisplay represents a method of using a specific type of hardware to render AR or VR realities and layers.
+
+_The VRDevice interface was renamed XRDisplay to denote that it is specifically for graphical display types and not other types of devices._
 
 A Pixel XL could expose several displays: a flat display, a magic window display, a Cardboard display, and a Daydream display.
 
@@ -46,7 +50,7 @@ A PC with no attached HMD could expose single a flat display.
 		attribute Reality reality; // Defaults to most recently used Reality
 
 
-		Reality createEmptyReality();
+		Reality createEmptyReality(DOMString name, boolean shared=false);
 		Promise<sequence <Reality>> getRealities();
 		Promise<boolean> requestRealityChange(Reality reality); // resolves true if the request is accepted
 
@@ -66,11 +70,14 @@ A PC with no attached HMD could expose single a flat display.
 
 A script that wishes to make use of an XRDisplay can request an XRSession. This session provides a list of the available realities that the script may request as well as access to the frame of reference,  and sampling frames.
 
+_The XRSession plays the same basic role as the VRSession, with the addition of Reality management._
+
 ## Reality
 
 	interface Reality : EventTarget {
 		readonly atttribute DOMString realityName;
 		readonly attribute XRCoordinates stageLocation;
+		readonly attribute isShared; // True if sessions other than the creator can access this Reality
 		readonly attribute isPassthrough; // True if the Reality is a view of the outside world, not a fully VR
 
 		Promise<boolean> changeStageLocation(XRCoordinates coordinates);
@@ -152,6 +159,8 @@ A script can request an empty Reality from the session in order to create a full
 		XRDisplayPose? getDisplayPose(XRCoordinateSystem coordinateSystem);
 	};
 
+_The XRPresentationFrame differs from the VRPresentationFrame with the addition of the point cloud, manifold, light estimates, and anchor management._
+
 ### Todo
 
 - access camera image buffer aor texture
@@ -185,6 +194,8 @@ A script can request an empty Reality from the session in order to create a full
 		attribute double altitudeAccuracy;
 		attribute Float32Array orientation; // quaternion from 0,0,0,1 EUS?
 	}
+
+The XRCartographicCoordinates are used in conjunction with the XRCoordinateSystem to represent a frame of reference that may optionally be positioned in relation to the nearest planet.
 
 ## XRCoordinateSystem
 

--- a/PSEUDO API 1.md
+++ b/PSEUDO API 1.md
@@ -8,7 +8,7 @@
 
 ## XRDisplay
 
-	interface XRDisplay {
+	interface XRDisplay : EventTarget {
 		readonly attribute DOMString displayName;
 		readonly attribute boolean isExternal;
 
@@ -20,15 +20,17 @@
 
 ### Todo
 
-- indicate that the display is opaque or clear
-- calibration
+- calibration and orientation reset
 
 ## Reality
 
-	interface Reality {
+	interface Reality : EventTarget {
 		readonly atttribute DOMString realityName;
-		readonly attribute boolean hasPointCloud;
 		readonly attribute XRCoordinates stageLocation;
+		readonly attribute isPassthrough; // True if the Reality is a view of the outside world, not a fully VR
+
+		readonly attribute boolean hasPointCloud;
+		readonly attribute boolean hasLightEstimate;
 
 		Promise<boolean> requestStageLocation(float x, float y float z, XRCoordinates)
 		Promise<boolean> requestResetStageLocation()
@@ -42,11 +44,11 @@
 
 ### Todo
 
-- requesting reality data (e.g. camera image)
+- requesting a different reality data (e.g. camera image, VR "empty" reality, or a map "street view")
 - configuration
-- anchors
+- offer a manifold aor a point cloud?
 - picking
-- manifold instead of point cloud
+
 
 ## XRPointCloud
 
@@ -59,6 +61,20 @@
 	interface XRLightEstimate {
 		readonly attribute float ambientIntensity;
 		readonly attribute float ambientColorTemperature;
+	}
+
+## XRAnchor
+
+	interface XRAnchor {
+		readonly attribute long id;
+		readonly attribute Float32Array center; // x, y, z
+	}
+
+## XRPlaneAnchor
+
+	interface XRPlaneAnchor : XRAnchor {
+		readonly attribute Float32Array orientation; // quaternion?
+		readonly attribute Float32Array extent; // width, length
 	}
 
 ## XRSession
@@ -80,6 +96,9 @@
 		long requestFrame(XRFrameRequestCallback callback);
 		void cancelFrame(long handle);
 
+		long addAnchor(XRAnchor anchor);
+		void removeAnchor(long id);
+
 		Promise<void> endSession();
 
 		attribute EventHandler onblur;
@@ -95,23 +114,6 @@
 
 		XRDisplayPose? getDisplayPose(XRCoordinateSystem coordinateSystem);
 	};
-
-## XRCoordinateSystem
-
-	interface XRCoordinateSystem: EventTarget {
-		readonly attribute Coordinates? coordinates; // https://dev.w3.org/geo/api/spec-source.html#coordinates
-
-		Float32Array? getTransformTo(XRCoordinateSystem other);
-	};
-
-## XRCoordinates
-
-	interface XRCoordinates {
-		readonly attribute XRCoordinateSystem
-		attribute float x;
-		attribute float y;
-		attribute float z;
-	}
 
 ## XRView
 
@@ -130,6 +132,23 @@
 		readonly attribute long width;
 		readonly attribute long height;
 	};
+
+## XRCoordinateSystem
+
+	interface XRCoordinateSystem: EventTarget {
+		readonly attribute Coordinates? coordinates; // https://dev.w3.org/geo/api/spec-source.html#coordinates
+
+		Float32Array? getTransformTo(XRCoordinateSystem other);
+	};
+
+## XRCoordinates
+
+	interface XRCoordinates {
+		readonly attribute XRCoordinateSystem
+		attribute float x;
+		attribute float y;
+		attribute float z;
+	}
 
 ## XRDisplayPose
 

--- a/PSEUDO API 1.md
+++ b/PSEUDO API 1.md
@@ -43,9 +43,6 @@
 		long requestFrame(XRFrameRequestCallback callback);
 		void cancelFrame(long handle);
 
-		long addAnchor(XRAnchor anchor);
-		void removeAnchor(long id);
-
 		Promise<void> endSession();
 
 		attribute EventHandler onblur;
@@ -62,15 +59,8 @@
 		readonly attribute XRCoordinates stageLocation;
 		readonly attribute isPassthrough; // True if the Reality is a view of the outside world, not a fully VR
 
-		readonly attribute boolean hasPointCloud;
-		readonly attribute boolean hasLightEstimate;
-
 		Promise<boolean> requestStageLocation(float x, float y float z, XRCoordinates)
 		Promise<boolean> requestResetStageLocation()
-
-		Promise<XRPointCloud> getPointCloud()
-
-		Promise<XRLightEstimate> getLightEstimate()
 
 		attribute EventHandler onchange;
 	};
@@ -112,6 +102,17 @@
 
 	interface XRPresentationFrame {
 		readonly attribute FrozenArray<XRView> views;
+
+		readonly attribute boolean hasPointCloud;
+		readonly attribute boolean hasLightEstimate;
+
+		Promise<XRPointCloud> getPointCloud()
+		Promise<XRLightEstimate> getLightEstimate()
+
+		long addAnchor(XRAnchor anchor);
+		void removeAnchor(long id);
+		XRAnchor? getAnchor(long id);
+		<sequence <XRAnchor>> getAnchors();
 
 		XRDisplayPose? getDisplayPose(XRCoordinateSystem coordinateSystem);
 	};

--- a/PSEUDO API 1.md
+++ b/PSEUDO API 1.md
@@ -20,7 +20,40 @@
 
 ### Todo
 
-- calibration and orientation reset
+- calibration
+- orientation reset
+
+## XRSession
+
+	interface XRSession : EventTarget {
+		readonly attribute XRDisplay display;
+		readonly attribute XRSessionCreateParameters createParameters;
+
+		attribute double depthNear;
+		attribute double depthFar;
+
+		attribute XRLayer layer;
+		attribute Reality reality; // Defaults to an empty (VR) reality
+
+		Promise<sequence <Reality>> getRealities(); // Always returns at least the default empty reality
+		Promise<boolean> requestRealityChange(Reality reality); // resolves true if the request is accepted
+
+		Promise<XRFrameOfReference> requestFrameOfReference(XRFrameOfReferenceType type);
+
+		long requestFrame(XRFrameRequestCallback callback);
+		void cancelFrame(long handle);
+
+		long addAnchor(XRAnchor anchor);
+		void removeAnchor(long id);
+
+		Promise<void> endSession();
+
+		attribute EventHandler onblur;
+		attribute EventHandler onfocus;
+		attribute EventHandler onresetpose;
+		attribute EventHandler onended;
+		attribute EventHandler onrealitychanged;
+	};
 
 ## Reality
 
@@ -44,10 +77,8 @@
 
 ### Todo
 
-- requesting a different reality data (e.g. camera image, VR "empty" reality, or a map "street view")
-- configuration
+- configuration (e.g. change white balance on camera input, change options on map view)
 - offer a manifold aor a point cloud?
-- picking
 
 
 ## XRPointCloud
@@ -76,36 +107,6 @@
 		readonly attribute Float32Array orientation; // quaternion?
 		readonly attribute Float32Array extent; // width, length
 	}
-
-## XRSession
-
-	interface XRSession : EventTarget {
-		readonly attribute XRDisplay display;
-		readonly attribute XRSessionCreateParameters createParameters;
-
-		attribute double depthNear;
-		attribute double depthFar;
-
-		attribute XRLayer layer;
-		attribute Reality reality;
-
-		Promise<sequence <Reality>> getRealities();
-
-		Promise<XRFrameOfReference> requestFrameOfReference(XRFrameOfReferenceType type);
-
-		long requestFrame(XRFrameRequestCallback callback);
-		void cancelFrame(long handle);
-
-		long addAnchor(XRAnchor anchor);
-		void removeAnchor(long id);
-
-		Promise<void> endSession();
-
-		attribute EventHandler onblur;
-		attribute EventHandler onfocus;
-		attribute EventHandler onresetpose;
-		attribute EventHandler onended;
-	};
 
 ## XRPresentationFrame
 
@@ -160,7 +161,18 @@
 
 ## XRLayer
 
-	interface XRLayer {};
+	interface XRLayer : EventTarget {
+		readonly attribute boolean hasFocus;
+
+		attribute EventHandler onfocus;
+		attribute EventHandler onblur;
+	};
+
+### Todo
+
+- misbehavior: visual, CPU, GPU, network
+
+## XRWebGLLayer
 
 	typedef (WebGLRenderingContext or WebGL2RenderingContext) XRWebGLRenderingContext;
 
@@ -182,8 +194,4 @@
 		void requestViewportScaling(double viewportScaleFactor);
 	};
 
-### Todo
-
-- focus / blur
-- misbehavior
 

--- a/PSEUDO API 1.md
+++ b/PSEUDO API 1.md
@@ -80,6 +80,8 @@ _The XRSession plays the same basic role as the VRSession, with the addition of 
 		readonly attribute isShared; // True if sessions other than the creator can access this Reality
 		readonly attribute isPassthrough; // True if the Reality is a view of the outside world, not a fully VR
 
+		Promise<XRLayer?> requestLayer(); // Null if the UA refuses access from this script context to the layer for this reality
+
 		Promise<boolean> changeStageLocation(XRCoordinates coordinates);
 		Promise<boolean> resetStageLocation();
 
@@ -88,9 +90,9 @@ _The XRSession plays the same basic role as the VRSession, with the addition of 
 
 A Reality represents a view of the world, be it the real world via sensors or a virtual world that is rendered with WebGL or WebGPU.
 
-Realities can be shared among XRSessions, with multiple scripts rendering into their separate XRLayer.context that are then composited by the UA with the Reality being the rearmost layer.
+Realities can be shared among XRSessions, with multiple scripts rendering into their separate XRLayer.context that are then composited by the UA with the Reality layer being the rearmost layer.
 
-A script can request an empty Reality from the session in order to create a fully virtual environment.
+A script can request an empty Reality from the session in order to create a fully virtual environment by requesting and then rendering into the Reality's XRLayer.
 
 ### Todo
 - Need to expose the stage origin and bounds

--- a/examples/ar_examples.js
+++ b/examples/ar_examples.js
@@ -41,6 +41,38 @@ class ARSetupExample {
 
 	handleFrame(frame){
 		this.session.requestFrame(frame => { this.handleFrame(frame) })
+	}
+}
+
+class ARAnchorExample extends ARSetupExample {
+
+	constructor(){
+		super()
+		this.anchorsToAdd = [] // { node, x, y, z }
+		this.anchoredModels = []
+	}
+
+	addAnchoredModel(sceneGraphNode, x, y, z){
+		this.anchorsToAdd.push({
+			node: sceneGraphNode,
+			x: x, y: y, z: z
+		})
+	}
+
+	handleFrame(frame){
+		this.session.requestFrame(frame => { this.handleFrame(frame) })
+
+		for(let anchorToAdd of this.anchorToAdd){
+			const anchorId = frame.addAnchor(new XRAnchor(x, y, z))
+			this.anchoredModels.push({
+				anchorId: anchorId,
+				node: anchorToAdd.node
+			})
+		}
+		
+		// update model position in the scene graph using anchors
+
 		// render into this.session.layer.context
+
 	}
 }

--- a/examples/ar_examples.js
+++ b/examples/ar_examples.js
@@ -1,0 +1,46 @@
+
+
+class ARSetupExample {
+	constructor(){
+		this.display = null
+		this.session = null
+
+		navigator.XR.getDisplays().then(displays => {
+			if(displays.length == 0) {
+				console.log('No displays are available')
+				return
+			}
+			this.display = displays[0] // production code would allow the user to choose			
+			this.display.requestSession({ exclusive: true }).then(session => {
+				this.handleNewSession(session)
+			}).catch(err => {
+				console.error('Could not initiate the session', err)
+			})
+		})
+	}
+
+	handleNewSession(session){
+		this.session = session
+		// Session defaults to an empty Reality so query for new ones
+		this.session.getRealities().then(realities => {
+			for(let reality of realities){
+				if(reality.isPassthrough){
+					this.session.requestRealityChange(reality).then(changed => {
+						if(changed === false){
+							console.log('Could not change realities')
+							return
+						}
+						// Now we have a session with a passthrough reality, so start rendering
+						this.session.requestFrame(frame => { this.handleFrame(frame) })
+					})
+					break
+				}
+			}
+		})
+	}
+
+	handleFrame(frame){
+		this.session.requestFrame(frame => { this.handleFrame(frame) })
+		// render into this.session.layer.context
+	}
+}

--- a/examples/vr_examples.js
+++ b/examples/vr_examples.js
@@ -20,8 +20,13 @@ class VRSetupExample {
 
 	handleNewSession(session){
 		this.session = session
-		// Session defaults to an empty Reality so just start rendering
-		this.session.requestFrame(frame => { this.handleFrame(frame) })
+		this.session.requestRealityChange(this.session.createEmptyReality()).then(changed => {
+			if(changed === false){
+				console.error('Could not change realities')
+				return
+			}
+			this.session.requestFrame(frame => { this.handleFrame(frame) })
+		})
 	}
 
 	handleFrame(frame){

--- a/examples/vr_examples.js
+++ b/examples/vr_examples.js
@@ -1,0 +1,31 @@
+
+class VRSetupExample {
+	constructor(){
+		this.display = null
+		this.session = null
+
+		navigator.XR.getDisplays().then(displays => {
+			if(displays.length == 0) {
+				console.log('No displays are available')
+				return
+			}
+			this.display = displays[0] // production code would allow the user to choose
+			this.display.requestSession({ exclusive: true }).then(session => {
+				this.handleNewSession(session)
+			}).catch(err => {
+				console.error('Could not initiate the session', err)
+			})
+		})
+	}
+
+	handleNewSession(session){
+		this.session = session
+		// Session defaults to an empty Reality so just start rendering
+		this.session.requestFrame(frame => { this.handleFrame(frame) })
+	}
+
+	handleFrame(frame){
+		this.session.requestFrame(frame => { this.handleFrame(frame) })
+		// render into this.session.layer.context
+	}
+}


### PR DESCRIPTION
Ok, I took a stab at a combined VR/AR/XR API that takes the as of yet unimplemented WebVR spec (https://w3c.github.io/webvr/spec/latest/#vrstageboundspoint) and imagined what it would look like if it was unified with the things we're discussing.

The purpose of this is to start nailing down the APIs that a developer might use to write a simple AR layer. There are notes about specific small items that aren't addressed, but there are also bigger items:

- what is in charge of rendering controllers (e.g. Vive wands)? The currently focused layer?
- where do vision libs (e.g. facial recognition or furniture recognition) fit?
- how do devs write long running augs?
- how do users manager long running augs?
 